### PR TITLE
Add default hawtio settings to wrapper.conf ERB template.

### DIFF
--- a/templates/wrapper.conf.erb
+++ b/templates/wrapper.conf.erb
@@ -57,6 +57,10 @@ wrapper.java.additional.8=-Dorg.apache.activemq.UseDedicatedTaskRunner=true
 wrapper.java.additional.9=-Djava.util.logging.config.file=logging.properties
 wrapper.java.additional.10=-Dactivemq.conf=%ACTIVEMQ_CONF%
 wrapper.java.additional.11=-Dactivemq.data=%ACTIVEMQ_DATA%
+wrapper.java.additional.12=-Dhawtio.realm=activemq
+wrapper.java.additional.13=-Dhawtio.role=admins
+wrapper.java.additional.14=-Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal
+wrapper.java.additional.15=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
 
 # Uncomment to enable jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616 


### PR DESCRIPTION
Allows the hawtio console to use the default ActiveMQ security realm and login configurations in new installations.
Initial instructions from: http://activemq.2283324.n4.nabble.com/Hawto-log-in-td4673552.html
