### PR TITLE
Add option which makes the management of the user and group optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,8 @@ class activemq (
   $user               = $activemq::params::user,
   $group              = $activemq::params::group,
   $system_user        = $activemq::params::system_user,
+  $manage_user        = $activemq::params::manage_user,
+  $manage_group       = $activemq::params::manage_group,
   $max_memory         = $activemq::params::max_memory,
   $console            = $activemq::params::console,
   $package_type       = $activemq::params::package_type,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,9 @@ class activemq::params (
   $system_user    = true,
   $max_memory     = undef,
   $console        = true,
-  $package_type   = 'tarball'
+  $package_type   = 'tarball',
+  $manage_user    = true,
+  $manage_group   = true,
 ) {
 
   # path flag for the activemq init script template


### PR DESCRIPTION
Hi,

with this PR its possible to disable the user and group management. For backward compatibility the default is, that module manages the user and group. But you can disable the management with:

``` puppet
manage_user => false,
manage_group => false,
```

Regards,
Matthias
