### PR TITLE
Fix the architecture_flag variable lookup in activemq-init.d.erb

### DIFF
--- a/templates/activemq-init.d.erb
+++ b/templates/activemq-init.d.erb
@@ -31,8 +31,8 @@ APP_LONG_NAME="ActiveMQ Broker"
 ACTIVEMQ_HOME="<%= @home %>/activemq"
 
 # Wrapper
-WRAPPER_CMD="<%= @home %>/activemq/bin/linux-x86-<%= @architecture_flag  %>/wrapper"
-WRAPPER_CONF="<%= @home %>/activemq/bin/linux-x86-<%= @architecture_flag  %>/wrapper.conf"
+WRAPPER_CMD="<%= @home %>/activemq/bin/linux-x86-<%= scope.lookupvar('activemq::architecture_flag') %>/wrapper"
+WRAPPER_CONF="<%= @home %>/activemq/bin/linux-x86-<%= scope.lookupvar('activemq::architecture_flag') %>/wrapper.conf"
 
 # Priority at which to run the wrapper.  See "man nice" for valid priorities.
 #  nice is only used if a priority is specified.


### PR DESCRIPTION
Hi,

this PR fixes an issue with Puppet 3.6 where the architecture_flag variable lookup in activemq-init.d.erb isn't working anymore.

Regards,
Matthias
