### PR TITLE
Allowing the java executable path to be specified.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class activemq (
   $console            = $activemq::params::console,
   $package_type       = $activemq::params::package_type,
   $architecture_flag  = $activemq::params::architecture_flag,
+  $java_exec          = $activemq::params::java_exec,
   $activemqxml_source = undef,
 ) inherits activemq::params {
 

--- a/manifests/package/tarball.pp
+++ b/manifests/package/tarball.pp
@@ -6,6 +6,7 @@ class activemq::package::tarball (
   $system_user  = $activemq::system_user,
   $manage_user  = $activemq::manage_user,
   $manage_group = $activemq::manage_group,
+  $java_exec    = $activemq::java_exec,
 ) {
 
   # wget from https://github.com/maestrodev/puppet-wget

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class activemq::params (
   $package_type   = 'tarball',
   $manage_user    = true,
   $manage_group   = true,
+  $java_exec      = 'java',
 ) {
 
   # path flag for the activemq init script template

--- a/templates/wrapper.conf.erb
+++ b/templates/wrapper.conf.erb
@@ -27,7 +27,7 @@ set.default.ACTIVEMQ_DATA=%ACTIVEMQ_BASE%/data
 wrapper.working.dir=.
 
 # Java Application
-wrapper.java.command=java
+wrapper.java.command=<%= @java_exec %>
 
 # Java Main class.  This class must implement the WrapperListener interface
 #  or guarantee that the WrapperManager class is initialized.  Helper


### PR DESCRIPTION
Allowing the java executable path to be specified without having to use the java version in the PATH. This is still a backward compatible change as the default value is same as it was in the module before the change.
